### PR TITLE
Add owner permissions on current subscription

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "azurerm_client_config" "current" {}
 
 data "azurerm_subscription" "managed_by_launchpad" {
-  for_each        = toset(var.subscription_ids)
+  for_each        = toset(concat(var.subscription_ids, [data.azurerm_client_config.current.subscription_id]))
   subscription_id = each.key
 }
 

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -27,11 +27,11 @@ resource "azurerm_role_assignment" "management_group_owner" {
 }
 
 resource "azurerm_role_assignment" "subscription_owner" {
-  for_each = toset(var.subscription_ids)
+  for_each = data.azurerm_subscription.managed_by_launchpad
 
   principal_id         = azurerm_user_assigned_identity.this.principal_id
   role_definition_name = "Owner"
-  scope                = data.azurerm_subscription.managed_by_launchpad[each.key].id
+  scope                = each.value.id
 }
 
 resource "azurerm_role_assignment" "resource_specific" {

--- a/r-storage-account.tf
+++ b/r-storage-account.tf
@@ -22,6 +22,7 @@ resource "azurerm_storage_account" "this" {
   account_tier             = "Standard"
   account_replication_type = "RAGRS"
 
+  allow_nested_items_to_be_public   = false
   cross_tenant_replication_enabled  = false
   default_to_oauth_authentication   = true
   https_traffic_only_enabled        = true

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -56,7 +56,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
   upgrade_mode                 = "Automatic"
   secure_boot_enabled          = false
   vtpm_enabled                 = false
-  overprovision                = true
+  overprovision                = false
 
   # trigger instance update
   custom_data = base64encode("#cloud-config\n#${sha256(local.github_runner_script)}")

--- a/tests/examples/mocks/main.tfmock.hcl
+++ b/tests/examples/mocks/main.tfmock.hcl
@@ -1,7 +1,8 @@
 mock_data "azurerm_client_config" {
   defaults = {
-    tenant_id = "00000000-0000-0000-0000-000000000000"
-    object_id = "00000000-0000-0000-0000-000000000000"
+    object_id       = "00000000-0000-0000-0000-000000000000"
+    subscription_id = "00000000-0000-0000-0000-000000000000"
+    tenant_id       = "00000000-0000-0000-0000-000000000000"
   }
 }
 
@@ -9,6 +10,12 @@ mock_data "azurerm_management_group" {
   defaults = {
     id   = "/providers/Microsoft.Management/managementGroups/MG-MOCK"
     name = "MG-MOCK"
+  }
+}
+
+mock_data "azurerm_subscription" {
+  defaults = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000"
   }
 }
 


### PR DESCRIPTION
This pull request addresses issue #2 by adding the current subscription to the list of subscriptions where the Launchpad module will receive `Owner` permissions. This change ensures that the Launchpad has the necessary permissions to manage resources within its own subscription, aligning functionality with the previous plain Terraform Resource Launchpad deployment.

Moreover, this pull request changes two settings: `overprovision = false` on `azurerm_linux_virtual_machine_scale_set` and `allow_nested_items_to_be_public = false` on `azurerm_storage_account`, following the latest IaC Launchpad configuration.