### PR TITLE
Add Configurable Inputs and Outputs to Enhance Flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,21 @@ Default: `[]`
 
 ### <a name="input_name"></a> [name](#input\_name)
 
-Description: The base name used in all resources created by this module
+Description: The base name applied to all resources created by this module.
 
 Type: `string`
 
 Default: `"launchpad"`
+
+### <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix)
+
+Description: An optional suffix appended to the base name for all resources created by this module.
+
+**NOTE**: This suffix is not applied to resources that use a randomly generated suffix (e.g., Key Vault and Storage Account).
+
+Type: `string`
+
+Default: `""`
 
 ### <a name="input_runner_arch"></a> [runner\_arch](#input\_runner\_arch)
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ Type: `list(string)`
 
 Default: `[]`
 
+### <a name="input_name"></a> [name](#input\_name)
+
+Description: The base name used in all resources created by this module
+
+Type: `string`
+
+Default: `"launchpad"`
+
 ### <a name="input_runner_arch"></a> [runner\_arch](#input\_runner\_arch)
 
 Description: The CPU architecture to run the GitHub actions runner. Can be `x64` or `arm64`.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ Type: `list(string)`
 
 Default: `[]`
 
+### <a name="input_key_vault_virtual_network_subnet_ids"></a> [key\_vault\_virtual\_network\_subnet\_ids](#input\_key\_vault\_virtual\_network\_subnet\_ids)
+
+Description: A list of Subnet IDs that are allowed to access the Key Vault used by the Launchpad.
+
+Type: `list(string)`
+
+Default: `[]`
+
 ### <a name="input_name"></a> [name](#input\_name)
 
 Description: The base name applied to all resources created by this module.

--- a/README.md
+++ b/README.md
@@ -294,6 +294,18 @@ Description: The storage account name used by the Launchpad for the Terraform st
 
 Description: The tenant ID of the Azure user identity assigned to the Launchpad
 
+### <a name="output_key_vault_private_endpoint_private_ip_address"></a> [key\_vault\_private\_endpoint\_private\_ip\_address](#output\_key\_vault\_private\_endpoint\_private\_ip\_address)
+
+Description: The private IP address of the private endpoint used by the Key Vault.
+
+### <a name="output_network_security_group_id"></a> [network\_security\_group\_id](#output\_network\_security\_group\_id)
+
+Description: The ID of the Azure Network Security Group (NSG) associated with the Launchpad.
+
+### <a name="output_network_security_group_name"></a> [network\_security\_group\_name](#output\_network\_security\_group\_name)
+
+Description: The name of the Azure Network Security Group (NSG) associated with the Launchpad.
+
 ### <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id)
 
 Description: The ID of the subnet within the Virtual Network, associated with the Launchpad production environment.

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,21 @@ output "LAUNCHPAD_AZURE_TENANT_ID" {
   description = "The tenant ID of the Azure user identity assigned to the Launchpad"
 }
 
+output "key_vault_private_endpoint_private_ip_address" {
+  value       = one(azurerm_private_endpoint.key_vault.private_service_connection[*].private_ip_address)
+  description = "The private IP address of the private endpoint used by the Key Vault."
+}
+
+output "network_security_group_id" {
+  value       = azurerm_network_security_group.this.id
+  description = "The ID of the Azure Network Security Group (NSG) associated with the Launchpad."
+}
+
+output "network_security_group_name" {
+  value       = azurerm_network_security_group.this.name
+  description = "The name of the Azure Network Security Group (NSG) associated with the Launchpad."
+}
+
 output "subnet_id" {
   value       = azurerm_subnet.this.id
   description = "The ID of the subnet within the Virtual Network, associated with the Launchpad production environment."

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -1,5 +1,5 @@
 resource "azurerm_user_assigned_identity" "this" {
-  name                = "id-${var.name}-prd-${local.location_short[var.location]}"
+  name                = join("-", ["id", var.name, "prd", local.location_short[var.location], var.name_suffix])
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -1,5 +1,5 @@
 resource "azurerm_user_assigned_identity" "this" {
-  name                = "id-launchpad-prd-${local.location_short[var.location]}"
+  name                = "id-${var.name}-prd-${local.location_short[var.location]}"
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-key-vault.tf
+++ b/r-key-vault.tf
@@ -5,7 +5,7 @@ resource "random_string" "kvlaunchpadprd_suffix" {
 }
 
 resource "azurerm_key_vault" "this" {
-  name                = "kv${var.name}prd${local.location_short[var.location]}${random_string.kvlaunchpadprd_suffix.result}"
+  name                = join("", ["kv", var.name, "prd", local.location_short[var.location], random_string.kvlaunchpadprd_suffix.result])
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags
@@ -26,7 +26,7 @@ resource "azurerm_key_vault" "this" {
 }
 
 resource "azurerm_private_endpoint" "key_vault" {
-  name                = "pe-${azurerm_key_vault.this.name}-prd-${local.location_short[var.location]}"
+  name                = join("-", ["pe", azurerm_key_vault.this.name, "prd", local.location_short[var.location], var.name_suffix])
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-key-vault.tf
+++ b/r-key-vault.tf
@@ -5,7 +5,7 @@ resource "random_string" "kvlaunchpadprd_suffix" {
 }
 
 resource "azurerm_key_vault" "this" {
-  name                = "kvlaunchpadprd${local.location_short[var.location]}${random_string.kvlaunchpadprd_suffix.result}"
+  name                = "kv${var.name}prd${local.location_short[var.location]}${random_string.kvlaunchpadprd_suffix.result}"
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-network.tf
+++ b/r-network.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_network" "this" {
-  name                = "vnet-launchpad-prd-${local.location_short[var.location]}"
+  name                = "vnet-${var.name}-prd-${local.location_short[var.location]}"
   resource_group_name = var.resource_group_name
   location            = var.location
   tags                = var.tags
@@ -9,14 +9,14 @@ resource "azurerm_virtual_network" "this" {
 
 
 resource "azurerm_subnet" "this" {
-  name                 = "snet-launchpad-prd-${local.location_short[var.location]}"
+  name                 = "snet-${var.name}-prd-${local.location_short[var.location]}"
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = var.subnet_address_prefixes
 }
 
 resource "azurerm_network_security_group" "this" {
-  name                = "nsg-launchpad-prd-${local.location_short[var.location]}"
+  name                = "nsg-${var.name}-prd-${local.location_short[var.location]}"
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-network.tf
+++ b/r-network.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_network" "this" {
-  name                = "vnet-${var.name}-prd-${local.location_short[var.location]}"
+  name                = join("-", ["vnet", var.name, "prd", local.location_short[var.location], var.name_suffix])
   resource_group_name = var.resource_group_name
   location            = var.location
   tags                = var.tags
@@ -9,14 +9,14 @@ resource "azurerm_virtual_network" "this" {
 
 
 resource "azurerm_subnet" "this" {
-  name                 = "snet-${var.name}-prd-${local.location_short[var.location]}"
+  name                 = join("-", ["snet", var.name, "prd", local.location_short[var.location], var.name_suffix])
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = var.subnet_address_prefixes
 }
 
 resource "azurerm_network_security_group" "this" {
-  name                = "nsg-${var.name}-prd-${local.location_short[var.location]}"
+  name                = join("-", ["nsg", var.name, "prd", local.location_short[var.location], var.name_suffix])
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-storage-account.tf
+++ b/r-storage-account.tf
@@ -13,7 +13,7 @@ resource "azurerm_management_lock" "storage_account_lock" {
 }
 
 resource "azurerm_storage_account" "this" {
-  name                = "stlaunchpadprd${local.location_short[var.location]}${random_string.stlaunchpadprd_suffix.result}"
+  name                = "st${var.name}prd${local.location_short[var.location]}${random_string.stlaunchpadprd_suffix.result}"
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-storage-account.tf
+++ b/r-storage-account.tf
@@ -13,7 +13,7 @@ resource "azurerm_management_lock" "storage_account_lock" {
 }
 
 resource "azurerm_storage_account" "this" {
-  name                = "st${var.name}prd${local.location_short[var.location]}${random_string.stlaunchpadprd_suffix.result}"
+  name                = join("", ["st", var.name, "prd", local.location_short[var.location], random_string.stlaunchpadprd_suffix.result])
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags
@@ -58,7 +58,7 @@ resource "azurerm_storage_container" "this" {
 }
 
 resource "azurerm_private_endpoint" "storage_account" {
-  name                = "pe-${azurerm_storage_account.this.name}-prd-${local.location_short[var.location]}"
+  name                = join("-", ["pe", azurerm_storage_account.this.name, "prd", local.location_short[var.location], var.name_suffix])
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "this" {
-  name                = "vmss-${var.name}-prd-${local.location_short[var.location]}"
+  name                = join("-", ["vmss", var.name, "prd", local.location_short[var.location], var.name_suffix])
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -16,14 +16,14 @@ locals {
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "this" {
-  name                = "vmss-launchpad-prd-${local.location_short[var.location]}"
+  name                = "vmss-${var.name}-prd-${local.location_short[var.location]}"
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags
 
   admin_password                  = random_password.virtual_machine_scale_set_admin_password.result
   admin_username                  = local.admin_username
-  computer_name_prefix            = "vm-launchpad"
+  computer_name_prefix            = "vm-${var.name}"
   disable_password_authentication = false
   instances                       = var.runner_vm_instances
   sku                             = "Standard_D2plds_v5"

--- a/variables.tf
+++ b/variables.tf
@@ -38,8 +38,18 @@ variable "management_group_names" {
 
 variable "name" {
   type        = string
-  description = "The base name used in all resources created by this module"
+  description = "The base name applied to all resources created by this module."
   default     = "launchpad"
+}
+
+variable "name_suffix" {
+  type        = string
+  description = <<-EOD
+    An optional suffix appended to the base name for all resources created by this module.
+
+    **NOTE**: This suffix is not applied to resources that use a randomly generated suffix (e.g., Key Vault and Storage Account).
+  EOD
+  default     = ""
 }
 
 variable "resource_group_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "management_group_names" {
   description = "A list of management group in order the Launchpad gets Owner-permission in these management-groups."
 }
 
+variable "name" {
+  type        = string
+  description = "The base name used in all resources created by this module"
+  default     = "launchpad"
+}
+
 variable "resource_group_name" {
   description = "The name of the resource group in which the virtual machine should exist. Changing this forces a new resource to be created."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "key_vault_private_dns_zone_ids" {
   description = "A list of ID´s of DNS Zones in order to add the Private Endpoint of the Keyvault into your DNS Zones."
 }
 
+variable "key_vault_virtual_network_subnet_ids" {
+  type        = list(string)
+  description = "A list of Subnet IDs that are allowed to access the Key Vault used by the Launchpad."
+  default     = []
+}
+
 variable "location" {
   type        = string
   description = "The geographic location where the resources will be deployed. This is must be a region name supported by Azure."


### PR DESCRIPTION
This pull request implements the changes requested in issue #4. It introduces the following updates:

- **Inputs**  
  - Added `name` input to customize the base name of resources, allowing for easier migration and alignment with best practices.  
  - Added `dns_servers` input to configure the DNS servers for the virtual network as per the [`azurerm_virtual_network`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) documentation.  
  - Added `name_suffix` input to allow further customization of resource names.

- **Outputs**  
  - Added `network_security_group_id` output for use with resources like [`azurerm_network_watcher_flow_log`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_watcher_flow_log).  
  - Added `network_security_group_name` output for use with resources like [`azurerm_network_security_rule`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule).  
  - Added `private_ip_address` output for private endpoints, enabling use in resources like [`azurerm_network_security_rule`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule).

These changes enhance the module's configurability and align it with common practices, improving its flexibility for various use cases.