### PR TITLE
Make management_group_names Optional with Default Value

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,7 @@ variable "location" {
 variable "management_group_names" {
   type        = list(string)
   description = "A list of management group in order the Launchpad gets Owner-permission in these management-groups."
+  default     = [ ]
 }
 
 variable "name" {


### PR DESCRIPTION
Issue: [Unable to Use Module Without Specifying Management Groups](https://github.com/cloudeteer/terraform-azurerm-launchpad/issues/9)

### **PR Title**
"Make `management_group_names` Optional with Default Value"

---

### **PR Description**
This PR updates the `management_group_names` variable in the `cloudeteer/terraform-azurerm-launchpad` module to make it optional by adding a default value.

**Changes Made:**
- Updated the `variables.tf` file to include a default value of an empty list (`[]`) for the `management_group_names` variable.

**Impact:**
- Users can now use the module without explicitly providing `management_group_names` if they do not need management group configuration.
- The module's functionality remains intact for users who wish to specify management groups.

**Testing Steps:**
1. Use the module without defining `management_group_names` in the configuration.
2. Validate that the module works as expected with an empty list for `management_group_names`.