### PR TITLE
Add input variable `service_endpoints`

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,23 @@ Type: `string`
 
 Default: `1`
 
+### <a name="input_service_endpoints"></a> [service\_endpoints](#input\_service\_endpoints)
+
+Description:   The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage`.Global and `Microsoft.Web`.
+
+**NOTE**: In order to use `Microsoft.Storage.Global` service endpoint (which allows access to virtual networks in other regions), you must enable the `AllowGlobalTagsForStorage` feature in your subscription. This is currently a preview feature, please see the [official documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-cli#enabling-access-to-virtual-networks-in-other-regions-preview) for more information.
+
+Type: `list(string)`
+
+Default:
+
+```json
+[
+  "Microsoft.KeyVault",
+  "Microsoft.Storage"
+]
+```
+
 ### <a name="input_subscription_ids"></a> [subscription\_ids](#input\_subscription\_ids)
 
 Description: A list of subscription IDs, which the Launchpad will manage.Each must be exactly 36 characters long.

--- a/r-network.tf
+++ b/r-network.tf
@@ -13,6 +13,7 @@ resource "azurerm_subnet" "this" {
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = var.subnet_address_prefixes
+  service_endpoints    = var.service_endpoints
 }
 
 resource "azurerm_network_security_group" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,17 @@ variable "runner_vm_instances" {
   default     = 1
 }
 
+variable "service_endpoints" {
+  description = <<-EOD
+    The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage`.Global and `Microsoft.Web`.
+
+  **NOTE**: In order to use `Microsoft.Storage.Global` service endpoint (which allows access to virtual networks in other regions), you must enable the `AllowGlobalTagsForStorage` feature in your subscription. This is currently a preview feature, please see the [official documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-cli#enabling-access-to-virtual-networks-in-other-regions-preview) for more information.
+  EOD
+
+  type    = list(string)
+  default = ["Microsoft.KeyVault", "Microsoft.Storage"]
+}
+
 variable "subnet_address_prefixes" {
   type        = list(string)
   description = "A list of IP address prefixes (CIDR blocks) to be assigned to the subnet. Each entry in the list represents a CIDR block used to define the address space of the subnet within the virtual network."


### PR DESCRIPTION
This PR fixes #11 by adding a new input variable `service_enpoints` with a default value of `["Microsoft.KeyVault", "Microsoft.Storage"]`. This input variable is passed to the `azurerm_subnet` resource.