### PR TITLE
Do not create NSG when bringing own Subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,11 +346,11 @@ Description: The private IP address of the private endpoint used by the Key Vaul
 
 ### <a name="output_network_security_group_id"></a> [network\_security\_group\_id](#output\_network\_security\_group\_id)
 
-Description: The ID of the Azure Network Security Group (NSG) associated with the Launchpad.
+Description: The ID of the Azure Network Security Group (NSG) associated with the Launchpad. If `var.subnet_id` is specified, no Azure Network Security Group (NSG) ID is returned.
 
 ### <a name="output_network_security_group_name"></a> [network\_security\_group\_name](#output\_network\_security\_group\_name)
 
-Description: The name of the Azure Network Security Group (NSG) associated with the Launchpad.
+Description: The name of the Azure Network Security Group (NSG) associated with the Launchpad. If `var.subnet_id` is specified, no Azure Network Security Group (NSG) Name is returned.
 
 ### <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id)
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,13 +22,13 @@ output "key_vault_private_endpoint_private_ip_address" {
 }
 
 output "network_security_group_id" {
-  value       = azurerm_network_security_group.this.id
-  description = "The ID of the Azure Network Security Group (NSG) associated with the Launchpad."
+  value       = (var.subnet_id == null ? azurerm_network_security_group.this[0].id : null)
+  description = "The ID of the Azure Network Security Group (NSG) associated with the Launchpad. If `var.subnet_id` is specified, no Azure Network Security Group (NSG) ID is returned."
 }
 
 output "network_security_group_name" {
-  value       = azurerm_network_security_group.this.name
-  description = "The name of the Azure Network Security Group (NSG) associated with the Launchpad."
+  value       = (var.subnet_id == null ? azurerm_network_security_group.this[0].name : null)
+  description = "The name of the Azure Network Security Group (NSG) associated with the Launchpad. If `var.subnet_id` is specified, no Azure Network Security Group (NSG) Name is returned."
 }
 
 output "subnet_id" {

--- a/r-network.tf
+++ b/r-network.tf
@@ -32,5 +32,5 @@ resource "azurerm_network_security_group" "this" {
 resource "azurerm_subnet_network_security_group_association" "this" {
   count                     = var.create_subnet ? 1 : 0
   subnet_id                 = local.subnet_id
-  network_security_group_id = azurerm_network_security_group.this.id
+  network_security_group_id = azurerm_network_security_group.this[0].id
 }

--- a/r-network.tf
+++ b/r-network.tf
@@ -22,6 +22,7 @@ resource "azurerm_subnet" "this" {
 }
 
 resource "azurerm_network_security_group" "this" {
+  count               = var.create_subnet ? 1 : 0
   name                = join("-", compact(["nsg", var.name, "prd", local.location_short[var.location], var.name_suffix]))
   location            = var.location
   resource_group_name = var.resource_group_name
@@ -29,6 +30,7 @@ resource "azurerm_network_security_group" "this" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "this" {
+  count                     = var.create_subnet ? 1 : 0
   subnet_id                 = local.subnet_id
   network_security_group_id = azurerm_network_security_group.this.id
 }

--- a/tests/local/var_subnet_id.tftest.hcl
+++ b/tests/local/var_subnet_id.tftest.hcl
@@ -63,3 +63,15 @@ run "should_fail_with_given_subnet_id_and_create_subnet" {
   command         = plan
   expect_failures = [var.create_subnet]
 }
+
+run "should_fail_with_given_subnet_and_created_nsg" {
+  variables {
+   create_subnet = false
+    subnet_id     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/subnets/mysubnet1"
+  }
+  command = plan
+  assert {
+    condition = length(azurerm_network_security_group.this) == 0
+    error_message = "No Network Security Group (NSG) should be created if you bring your own Subnet."
+  }
+}

--- a/tests/local/var_subnet_id.tftest.hcl
+++ b/tests/local/var_subnet_id.tftest.hcl
@@ -66,12 +66,12 @@ run "should_fail_with_given_subnet_id_and_create_subnet" {
 
 run "should_fail_with_given_subnet_and_created_nsg" {
   variables {
-   create_subnet = false
+   create_subnet  = false
     subnet_id     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/subnets/mysubnet1"
   }
   command = plan
   assert {
-    condition = length(azurerm_network_security_group.this) == 0
+    condition     = length(azurerm_network_security_group.this) == 0
     error_message = "No Network Security Group (NSG) should be created if you bring your own Subnet."
   }
 }

--- a/tests/local/var_subnet_id.tftest.hcl
+++ b/tests/local/var_subnet_id.tftest.hcl
@@ -66,7 +66,7 @@ run "should_fail_with_given_subnet_id_and_create_subnet" {
 
 run "should_fail_with_given_subnet_and_created_nsg" {
   variables {
-   create_subnet  = false
+    create_subnet = false
     subnet_id     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/subnets/mysubnet1"
   }
   command = plan


### PR DESCRIPTION
With the new Feature of "Bring your own Subnet", the Azure Network Security Group (NSG) was still created, which does not make sense.

This PR will not create any NSG in case of BYO Subnet.