### PR TITLE
Add `create_key_vault` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### <a name="input_create_key_vault"></a> [create\_key\_vault](#input\_create\_key\_vault)
+
+Description: Create a central Key Vault which can be used to store secrets and keys securely during workload deployments.
+
+Type: `bool`
+
+Default: `true`
+
 ### <a name="input_create_role_assignments"></a> [create\_role\_assignments](#input\_create\_role\_assignments)
 
 Description: Determines whether to create role assignments for the specified management groups and subscriptions.
@@ -367,7 +375,7 @@ Description: The tenant ID of the Azure user identity assigned to the Launchpad
 
 ### <a name="output_key_vault_private_endpoint_private_ip_address"></a> [key\_vault\_private\_endpoint\_private\_ip\_address](#output\_key\_vault\_private\_endpoint\_private\_ip\_address)
 
-Description: The private IP address of the private endpoint used by the Key Vault.
+Description: The private IP address of the private endpoint associated with the Key Vault. This endpoint is created only if `create_key_vault` is set to `true`. If `create_key_vault` is `false`, this output will be `null`.
 
 ### <a name="output_network_security_group_id"></a> [network\_security\_group\_id](#output\_network\_security\_group\_id)
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,8 +17,8 @@ output "LAUNCHPAD_AZURE_TENANT_ID" {
 }
 
 output "key_vault_private_endpoint_private_ip_address" {
-  value       = one(azurerm_private_endpoint.key_vault.private_service_connection[*].private_ip_address)
-  description = "The private IP address of the private endpoint used by the Key Vault."
+  value       = var.create_key_vault ? (azurerm_private_endpoint.key_vault[0].private_service_connection[*].private_ip_address) : null
+  description = "The private IP address of the private endpoint associated with the Key Vault. This endpoint is created only if `create_key_vault` is set to `true`. If `create_key_vault` is `false`, this output will be `null`."
 }
 
 output "network_security_group_id" {

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -36,15 +36,17 @@ resource "azurerm_role_assignment" "subscription_owner" {
 
 resource "azurerm_role_assignment" "resource_specific" {
   for_each = var.create_role_assignments ? {
-    storage_blob_owner = {
-      role_definition_name = "Storage Blob Data Owner"
-      scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}"
-    },
-    key_vault_admin = {
-      role_definition_name = "Key Vault Administrator"
-      scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}"
-    }
-  } : {}
+    for key, value in {
+      storage_blob_owner = {
+        role_definition_name = "Storage Blob Data Owner"
+        scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}"
+      },
+      key_vault_admin = var.create_key_vault ? {
+        role_definition_name = "Key Vault Administrator"
+        scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}"
+      } : null
+  } : key => value if value != null } : {}
+
 
   principal_id         = azurerm_user_assigned_identity.this.principal_id
   scope                = each.value.scope

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -1,8 +1,8 @@
 locals {
   admin_username = "azureadmin"
   github_runner_script = base64gzip(templatefile("${path.module}/assets/install_github_actions_runner.sh.tftpl", {
-    key_vault_hostname                  = "${azurerm_key_vault.this.name}.vault.azure.net"
-    private_endpoint_key_vault_ip       = one(azurerm_private_endpoint.key_vault.private_service_connection[*].private_ip_address)
+    key_vault_hostname                  = var.create_key_vault ? "${azurerm_key_vault.this[0].name}.vault.azure.net" : "_key_vault_deployment_disabled_.localhost.local"
+    private_endpoint_key_vault_ip       = var.create_key_vault ? one(azurerm_private_endpoint.key_vault[0].private_service_connection[*].private_ip_address) : "127.0.0.1"
     private_endpoint_storage_account_ip = one(azurerm_private_endpoint.storage_account.private_service_connection[*].private_ip_address)
     storage_account_hostname            = azurerm_storage_account.this.primary_blob_host
 
@@ -133,11 +133,12 @@ resource "random_password" "virtual_machine_scale_set_admin_password" {
 #trivy:ignore:avd-azu-0017
 #trivy:ignore:avd-azu-0013
 resource "azurerm_key_vault_secret" "virtual_machine_scale_set_admin_password" {
+  count = var.create_key_vault ? 1 : 0
 
   name = "${azurerm_linux_virtual_machine_scale_set.this.name}-${azurerm_linux_virtual_machine_scale_set.this.admin_username}-password"
 
   content_type = "Password"
-  key_vault_id = azurerm_key_vault.this.id
+  key_vault_id = azurerm_key_vault.this[0].id
   value        = random_password.virtual_machine_scale_set_admin_password.result
 
   depends_on = [azurerm_role_assignment.key_vault_admin_current_user]

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "create_key_vault" {
+  type        = bool
+  default     = true
+  description = "Create a central Key Vault which can be used to store secrets and keys securely during workload deployments."
+}
+
 variable "create_role_assignments" {
   type        = bool
   default     = true


### PR DESCRIPTION
### Summary  
This PR makes the Key Vault optional in the module, allowing users to opt out when it is not required. When disabled, all associated resources are excluded from deployment.

### Changes  
- Introduced a configuration option to enable or disable Key Vault deployment.
- Updated resource definitions to conditionally provision Key Vault-related resources.
- Modified documentation to reflect the new behavior.

### Related Issue  
Closes #30

### Notes  
Feedback is welcome to ensure alignment with module requirements. 🚀