### PR TITLE
Expose `principal_id` of Launchpad Managed Identity  

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,10 @@ Description: The ID of the Azure Network Security Group (NSG) associated with th
 
 Description: The name of the Azure Network Security Group (NSG) associated with the Launchpad. If `var.subnet_id` is specified, no Azure Network Security Group (NSG) Name is returned.
 
+### <a name="output_principal_id"></a> [principal\_id](#output\_principal\_id)
+
+Description: The principal ID of the Azure user identity assigned to the Launchpad.
+
 ### <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id)
 
 Description: The ID of the subnet within the Virtual Network associated with the Launchpad. If `var.subnet_id` is specified, its value is used for this output. Otherwise, the ID of the subnet created by this module is returned.

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,6 +31,11 @@ output "network_security_group_name" {
   description = "The name of the Azure Network Security Group (NSG) associated with the Launchpad. If `var.subnet_id` is specified, no Azure Network Security Group (NSG) Name is returned."
 }
 
+output "principal_id" {
+  value       = azurerm_user_assigned_identity.this.principal_id
+  description = "The principal ID of the Azure user identity assigned to the Launchpad."
+}
+
 output "subnet_id" {
   value       = local.subnet_id
   description = "The ID of the subnet within the Virtual Network associated with the Launchpad. If `var.subnet_id` is specified, its value is used for this output. Otherwise, the ID of the subnet created by this module is returned."


### PR DESCRIPTION
This PR adds a Terraform output for the `principal_id` of the Launchpad's managed identity, making it easily accessible for further role assignments.  
