### PR TITLE
Undo release `v0.2.1` and `v0.2.2` (hotfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,29 +219,6 @@ Type: `string`
 
 Default: `"launchpad"`
 
-### <a name="input_name_overrides"></a> [name\_overrides](#input\_name\_overrides)
-
-Description: This variable allows you to overwrite generated names of most resources created by this module. This can be handy when importing existing resources to the Terraform state. e.g. using an existing storage Account but not bringing it into the module but import it into the state and let it be managed by the module.
-
-Type:
-
-```hcl
-object({
-    key_vault                      = optional(string)
-    key_vault_private_endpoint     = optional(string)
-    virtual_machine_scale_set_name = optional(string)
-    network_security_group         = optional(string)
-    storage_account                = optional(string)
-    storage_container              = optional(string)
-    storage_private_endpoint       = optional(string)
-    subnet                         = optional(string)
-    user_assigned_identity         = optional(string)
-    virtual_network                = optional(string)
-  })
-```
-
-Default: `{}`
-
 ### <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix)
 
 Description: An optional suffix appended to the base name for all resources created by this module.

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -1,14 +1,5 @@
-locals {
-  user_assigned_identity_name = coalesce(
-    var.name_overrides.user_assigned_identity,
-    join("-", compact([
-      "id", var.name, "prd", local.location_short[var.location], var.name_suffix
-    ]))
-  )
-}
-
 resource "azurerm_user_assigned_identity" "this" {
-  name                = local.user_assigned_identity_name
+  name                = join("-", compact(["id", var.name, "prd", local.location_short[var.location], var.name_suffix]))
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-key-vault.tf
+++ b/r-key-vault.tf
@@ -1,21 +1,5 @@
-locals {
-  key_vault_name = coalesce(
-    var.name_overrides.key_vault,
-    join("", compact([
-      "kv", var.name, "prd", local.location_short[var.location], random_string.kvlaunchpadprd_suffix[0].result
-    ]))
-  )
-
-  key_vault_private_endpoint_name = coalesce(
-    var.name_overrides.key_vault_private_endpoint,
-    join("-", compact([
-      "pe", azurerm_key_vault.this[0].name, "prd", local.location_short[var.location], var.name_suffix
-    ]))
-  )
-}
-
 resource "random_string" "kvlaunchpadprd_suffix" {
-  count = var.create_key_vault && var.name_overrides.key_vault == null ? 1 : 0
+  count = var.create_key_vault ? 1 : 0
 
   length  = 3
   special = false
@@ -38,7 +22,9 @@ resource "azurerm_management_lock" "key_vault_lock" {
 resource "azurerm_key_vault" "this" {
   count = var.create_key_vault ? 1 : 0
 
-  name                = local.key_vault_name
+  name = join("", compact([
+    "kv", var.name, "prd", local.location_short[var.location], random_string.kvlaunchpadprd_suffix[0].result
+  ]))
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags
@@ -62,7 +48,9 @@ resource "azurerm_key_vault" "this" {
 resource "azurerm_private_endpoint" "key_vault" {
   count = var.create_key_vault ? 1 : 0
 
-  name                = local.key_vault_private_endpoint_name
+  name = join("-", compact([
+    "pe", azurerm_key_vault.this[0].name, "prd", local.location_short[var.location], var.name_suffix
+  ]))
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-network.tf
+++ b/r-network.tf
@@ -1,25 +1,10 @@
 locals {
-  network_security_group_name = coalesce(
-    var.name_overrides.network_security_group,
-    join("-", compact(["nsg", var.name, "prd", local.location_short[var.location], var.name_suffix]))
-  )
-
-  subnet_id = coalesce(var.subnet_id, azurerm_subnet.this[0].id)
-
-  subnet_name = coalesce(
-    var.name_overrides.subnet,
-    join("-", compact(["snet", var.name, "prd", local.location_short[var.location], var.name_suffix]))
-  )
-
-  virtual_network_name = coalesce(
-    var.name_overrides.virtual_network,
-    join("-", compact(["vnet", var.name, "prd", local.location_short[var.location], var.name_suffix]))
-  )
+  subnet_id = var.subnet_id == null ? azurerm_subnet.this[0].id : var.subnet_id
 }
 
 resource "azurerm_virtual_network" "this" {
   count               = var.create_subnet ? 1 : 0
-  name                = local.virtual_network_name
+  name                = join("-", compact(["vnet", var.name, "prd", local.location_short[var.location], var.name_suffix]))
   resource_group_name = var.resource_group_name
   location            = var.location
   tags                = var.tags
@@ -29,7 +14,7 @@ resource "azurerm_virtual_network" "this" {
 
 resource "azurerm_subnet" "this" {
   count                = var.create_subnet ? 1 : 0
-  name                 = local.subnet_name
+  name                 = join("-", compact(["snet", var.name, "prd", local.location_short[var.location], var.name_suffix]))
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.this[0].name
   address_prefixes     = var.subnet_address_prefixes
@@ -38,7 +23,7 @@ resource "azurerm_subnet" "this" {
 
 resource "azurerm_network_security_group" "this" {
   count               = var.create_subnet ? 1 : 0
-  name                = local.network_security_group_name
+  name                = join("-", compact(["nsg", var.name, "prd", local.location_short[var.location], var.name_suffix]))
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-network.tf
+++ b/r-network.tf
@@ -4,7 +4,7 @@ locals {
     join("-", compact(["nsg", var.name, "prd", local.location_short[var.location], var.name_suffix]))
   )
 
-  subnet_id = var.subnet_id == null ? azurerm_subnet.this[0].id : var.subnet_id
+  subnet_id = coalesce(var.subnet_id, azurerm_subnet.this[0].id)
 
   subnet_name = coalesce(
     var.name_overrides.subnet,

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -13,15 +13,10 @@ locals {
     runner_user        = var.runner_user
     runner_version     = var.runner_version
   }))
-
-  virtual_machine_scale_set_name = coalesce(
-    var.name_overrides.virtual_machine_scale_set_name,
-    join("-", compact(["vmss", var.name, "prd", local.location_short[var.location], var.name_suffix]))
-  )
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "this" {
-  name                = local.virtual_machine_scale_set_name
+  name                = join("-", compact(["vmss", var.name, "prd", local.location_short[var.location], var.name_suffix]))
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -115,25 +115,6 @@ variable "name" {
   default     = "launchpad"
 }
 
-variable "name_overrides" {
-  description = "This variable allows you to overwrite generated names of most resources created by this module. This can be handy when importing existing resources to the Terraform state. e.g. using an existing storage Account but not bringing it into the module but import it into the state and let it be managed by the module."
-
-  type = object({
-    key_vault                      = optional(string)
-    key_vault_private_endpoint     = optional(string)
-    virtual_machine_scale_set_name = optional(string)
-    network_security_group         = optional(string)
-    storage_account                = optional(string)
-    storage_container              = optional(string)
-    storage_private_endpoint       = optional(string)
-    subnet                         = optional(string)
-    user_assigned_identity         = optional(string)
-    virtual_network                = optional(string)
-  })
-
-  default = {}
-}
-
 variable "name_suffix" {
   type        = string
   description = <<-EOD


### PR DESCRIPTION
- **Revert "Fix broken test on `v0.2.1` by undoing change on `local.subnet_id` (#32)"**
- **Revert "Add ability to overwrite resource names"**
