### PR TITLE
Allow overriding resource names via `name_overrides`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,29 @@ Type: `string`
 
 Default: `"launchpad"`
 
+### <a name="input_name_overrides"></a> [name\_overrides](#input\_name\_overrides)
+
+Description: This variable allows you to overwrite generated names of most resources created by this module. This can be handy when importing existing resources to the Terraform state. e.g. using an existing storage Account but not bringing it into the module but import it into the state and let it be managed by the module.
+
+Type:
+
+```hcl
+object({
+    key_vault                      = optional(string)
+    key_vault_private_endpoint     = optional(string)
+    virtual_machine_scale_set_name = optional(string)
+    network_security_group         = optional(string)
+    storage_account                = optional(string)
+    storage_container              = optional(string)
+    storage_private_endpoint       = optional(string)
+    subnet                         = optional(string)
+    user_assigned_identity         = optional(string)
+    virtual_network                = optional(string)
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix)
 
 Description: An optional suffix appended to the base name for all resources created by this module.

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -1,5 +1,14 @@
+locals {
+  user_assigned_identity_name = coalesce(
+    var.name_overrides.user_assigned_identity,
+    join("-", compact([
+      "id", var.name, "prd", local.location_short[var.location], var.name_suffix
+    ]))
+  )
+}
+
 resource "azurerm_user_assigned_identity" "this" {
-  name                = join("-", compact(["id", var.name, "prd", local.location_short[var.location], var.name_suffix]))
+  name                = local.user_assigned_identity_name
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-key-vault.tf
+++ b/r-key-vault.tf
@@ -1,5 +1,21 @@
+locals {
+  key_vault_name = coalesce(
+    var.name_overrides.key_vault,
+    join("", compact([
+      "kv", var.name, "prd", local.location_short[var.location], one(random_string.kvlaunchpadprd_suffix[*].result)
+    ]))
+  )
+
+  key_vault_private_endpoint_name = coalesce(
+    var.name_overrides.key_vault_private_endpoint,
+    join("-", compact([
+      "pe", one(azurerm_key_vault.this[*].name), "prd", local.location_short[var.location], var.name_suffix
+    ]))
+  )
+}
+
 resource "random_string" "kvlaunchpadprd_suffix" {
-  count = var.create_key_vault ? 1 : 0
+  count = var.create_key_vault && var.name_overrides.key_vault == null ? 1 : 0
 
   length  = 3
   special = false
@@ -22,9 +38,7 @@ resource "azurerm_management_lock" "key_vault_lock" {
 resource "azurerm_key_vault" "this" {
   count = var.create_key_vault ? 1 : 0
 
-  name = join("", compact([
-    "kv", var.name, "prd", local.location_short[var.location], random_string.kvlaunchpadprd_suffix[0].result
-  ]))
+  name                = local.key_vault_name
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags
@@ -48,9 +62,7 @@ resource "azurerm_key_vault" "this" {
 resource "azurerm_private_endpoint" "key_vault" {
   count = var.create_key_vault ? 1 : 0
 
-  name = join("-", compact([
-    "pe", azurerm_key_vault.this[0].name, "prd", local.location_short[var.location], var.name_suffix
-  ]))
+  name                = local.key_vault_private_endpoint_name
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-network.tf
+++ b/r-network.tf
@@ -1,10 +1,25 @@
 locals {
-  subnet_id = var.subnet_id == null ? azurerm_subnet.this[0].id : var.subnet_id
+  network_security_group_name = coalesce(
+    var.name_overrides.network_security_group,
+    join("-", compact(["nsg", var.name, "prd", local.location_short[var.location], var.name_suffix]))
+  )
+
+  subnet_id = coalesce(var.subnet_id, one(azurerm_subnet.this[*].id))
+
+  subnet_name = coalesce(
+    var.name_overrides.subnet,
+    join("-", compact(["snet", var.name, "prd", local.location_short[var.location], var.name_suffix]))
+  )
+
+  virtual_network_name = coalesce(
+    var.name_overrides.virtual_network,
+    join("-", compact(["vnet", var.name, "prd", local.location_short[var.location], var.name_suffix]))
+  )
 }
 
 resource "azurerm_virtual_network" "this" {
   count               = var.create_subnet ? 1 : 0
-  name                = join("-", compact(["vnet", var.name, "prd", local.location_short[var.location], var.name_suffix]))
+  name                = local.virtual_network_name
   resource_group_name = var.resource_group_name
   location            = var.location
   tags                = var.tags
@@ -14,7 +29,7 @@ resource "azurerm_virtual_network" "this" {
 
 resource "azurerm_subnet" "this" {
   count                = var.create_subnet ? 1 : 0
-  name                 = join("-", compact(["snet", var.name, "prd", local.location_short[var.location], var.name_suffix]))
+  name                 = local.subnet_name
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.this[0].name
   address_prefixes     = var.subnet_address_prefixes
@@ -23,7 +38,7 @@ resource "azurerm_subnet" "this" {
 
 resource "azurerm_network_security_group" "this" {
   count               = var.create_subnet ? 1 : 0
-  name                = join("-", compact(["nsg", var.name, "prd", local.location_short[var.location], var.name_suffix]))
+  name                = local.network_security_group_name
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-storage-account.tf
+++ b/r-storage-account.tf
@@ -1,4 +1,24 @@
+locals {
+  storage_account_name = coalesce(
+    var.name_overrides.storage_account,
+    join("", compact([
+      "st", var.name, "prd", local.location_short[var.location], one(random_string.stlaunchpadprd_suffix[*].result)
+    ]))
+  )
+
+  storage_container_name = coalesce(var.name_overrides.storage_container, "tfstate")
+
+  storage_private_endpoint_name = coalesce(
+    var.name_overrides.storage_private_endpoint,
+    join("-", compact([
+      "pe", azurerm_storage_account.this.name, "prd", local.location_short[var.location], var.name_suffix
+    ]))
+  )
+}
+
 resource "random_string" "stlaunchpadprd_suffix" {
+  count = var.name_overrides.storage_account != null ? 0 : 1
+
   length  = 3
   special = false
   upper   = false
@@ -13,9 +33,7 @@ resource "azurerm_management_lock" "storage_account_lock" {
 }
 
 resource "azurerm_storage_account" "this" {
-  name = join("", compact([
-    "st", var.name, "prd", local.location_short[var.location], random_string.stlaunchpadprd_suffix.result
-  ]))
+  name                = local.storage_account_name
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags
@@ -54,15 +72,13 @@ resource "azurerm_storage_account" "this" {
 }
 
 resource "azurerm_storage_container" "this" {
-  name                  = "tfstate"
+  name                  = local.storage_container_name
   storage_account_name  = azurerm_storage_account.this.name
   container_access_type = "private"
 }
 
 resource "azurerm_private_endpoint" "storage_account" {
-  name = join("-", compact([
-    "pe", azurerm_storage_account.this.name, "prd", local.location_short[var.location], var.name_suffix
-  ]))
+  name                = local.storage_private_endpoint_name
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -13,10 +13,15 @@ locals {
     runner_user        = var.runner_user
     runner_version     = var.runner_version
   }))
+
+  virtual_machine_scale_set_name = coalesce(
+    var.name_overrides.virtual_machine_scale_set_name,
+    join("-", compact(["vmss", var.name, "prd", local.location_short[var.location], var.name_suffix]))
+  )
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "this" {
-  name                = join("-", compact(["vmss", var.name, "prd", local.location_short[var.location], var.name_suffix]))
+  name                = local.virtual_machine_scale_set_name
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/tests/local/input_create_key_vault.tftest.hcl
+++ b/tests/local/input_create_key_vault.tftest.hcl
@@ -2,10 +2,35 @@ mock_provider "azurerm" {
   source = "./tests/local/mocks"
 }
 
-run "succeed_without_key_vault_creation" {
+run "should_succeed_without_key_vault_creation" {
   command = plan
 
   variables {
     create_key_vault = false
+  }
+
+  assert {
+    condition     = length(azurerm_key_vault.this) == 0
+    error_message = "Expected that the Key Vault resource will not be created"
+  }
+
+  assert {
+    condition     = length(random_string.kvlaunchpadprd_suffix) == 0
+    error_message = "Expected that the random string for Key Vault suffix will not be created"
+  }
+
+  assert {
+    condition     = length(azurerm_management_lock.key_vault_lock) == 0
+    error_message = "Expected that the Key Vault management lock will not be created"
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.key_vault) == 0
+    error_message = "Expected that the Key Vault private endpoint will not be created"
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.key_vault_admin_current_user) == 0
+    error_message = "Expected that the Key Vault admin role assignment for the current user will not be created"
   }
 }

--- a/tests/local/input_create_key_vault.tftest.hcl
+++ b/tests/local/input_create_key_vault.tftest.hcl
@@ -1,0 +1,11 @@
+mock_provider "azurerm" {
+  source = "./tests/local/mocks"
+}
+
+run "succeed_without_key_vault_creation" {
+  command = plan
+
+  variables {
+    create_key_vault = false
+  }
+}

--- a/tests/local/input_name_overrides.tftest.hcl
+++ b/tests/local/input_name_overrides.tftest.hcl
@@ -1,0 +1,41 @@
+mock_provider "azurerm" {
+  source = "./tests/local/mocks"
+}
+
+run "should_succeed_without_key_vault_creation" {
+  command = plan
+
+  variables {
+    name_overrides = {
+      for resource in [
+        "key_vault",
+        "key_vault_private_endpoint",
+        "virtual_machine_scale_set_name",
+        "network_security_group",
+        "storage_account",
+        "storage_container",
+        "storage_private_endpoint",
+        "subnet",
+        "user_assigned_identity",
+        "virtual_network",
+      ] : resource => "tftest"
+    }
+  }
+
+  assert {
+    condition = alltrue([for resource in [
+      azurerm_key_vault.this,
+      azurerm_private_endpoint.key_vault,
+      azurerm_linux_virtual_machine_scale_set.this,
+      azurerm_network_security_group.this,
+      azurerm_storage_account.this,
+      azurerm_storage_container.this,
+      azurerm_private_endpoint.storage_account,
+      azurerm_subnet.this,
+      azurerm_user_assigned_identity.this,
+      azurerm_virtual_network.this,
+      ] : one(resource[*].name) == "tftest"
+    ])
+    error_message = "Expected the name of the resource to be overwritten with the value \"tftest\"."
+  }
+}

--- a/tests/local/var_subnet_id.tftest.hcl
+++ b/tests/local/var_subnet_id.tftest.hcl
@@ -2,6 +2,12 @@ mock_provider "azurerm" {
   source = "./tests/local/mocks"
 }
 
+# Unset variables set as default in variables.auto.tfvars
+variables {
+  subnet_address_prefixes       = []
+  virtual_network_address_space = []
+}
+
 run "should_succeed_with_existing_subnet_id" {
   variables {
     create_subnet = false

--- a/tests/local/variables.auto.tfvars
+++ b/tests/local/variables.auto.tfvars
@@ -1,6 +1,11 @@
+# mandatory variables
 location               = "germanywestcentral"
 management_group_names = ["mg-test-1", "mg-test-2"]
 resource_group_name    = "rg-test-1"
 runner_github_pat      = "github_pat_0000000000000000000000_00000000000000000000000000000000000000000000000000000000000"
 runner_github_repo     = "owner/repo"
 subscription_ids       = ["00000000-0000-0000-0000-000000000000"]
+
+# semi-mandatory variables, these are mandatory unless specific features are disabled
+subnet_address_prefixes       = ["192.168.0.0/24"]
+virtual_network_address_space = ["192.168.0.0/24"]

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,25 @@ variable "name" {
   default     = "launchpad"
 }
 
+variable "name_overrides" {
+  description = "This variable allows you to overwrite generated names of most resources created by this module. This can be handy when importing existing resources to the Terraform state. e.g. using an existing storage Account but not bringing it into the module but import it into the state and let it be managed by the module."
+
+  type = object({
+    key_vault                      = optional(string)
+    key_vault_private_endpoint     = optional(string)
+    virtual_machine_scale_set_name = optional(string)
+    network_security_group         = optional(string)
+    storage_account                = optional(string)
+    storage_container              = optional(string)
+    storage_private_endpoint       = optional(string)
+    subnet                         = optional(string)
+    user_assigned_identity         = optional(string)
+    virtual_network                = optional(string)
+  })
+
+  default = {}
+}
+
 variable "name_suffix" {
   type        = string
   description = <<-EOD


### PR DESCRIPTION
This PR introduces the `name_overrides` variable, allowing users to specify custom resource names instead of relying on the module's default naming conventions. This is particularly useful for cases where existing resources need to be imported and managed without renaming.  

#### Changes Introduced  

- Added a `name_overrides` variable to allow custom resource names.  
- Implemented a Terraform test to validate name overriding functionality.  
- Improved local tests for better reliability.  
- Added a missing test for the `create_key_vault` variable when set to `false`.  

### Motivation & Use Case  

Users managing pre-existing infrastructure, such as a storage account holding Terraform states, require the ability to retain existing resource names. This change provides the necessary flexibility while maintaining the default behavior for those who do not need custom names.  
