### PR TITLE
Create missing SSH directory

### DIFF
--- a/assets/install_github_actions_runner.sh.tftpl
+++ b/assets/install_github_actions_runner.sh.tftpl
@@ -71,6 +71,7 @@ id "$RUNNER_USER" &>/dev/null || useradd --create-home --system \
   "$RUNNER_USER"
 
 # Add GitHub SSH host keys to known hosts
+sudo -u "$RUNNER_USER" -- mkdir -d /home/$RUNNER_USER/.ssh
 sudo -u "$RUNNER_USER" -- ssh-keyscan -t rsa github.com | sudo -u "$RUNNER_USER" -- tee -a "/home/$RUNNER_USER/.ssh/known_hosts"
 
 # Create base install directory


### PR DESCRIPTION
This PR fixes this error in the install script:

```
tee: /home/actions-runner/.ssh/known_hosts: No such file or directory
```