### PR TITLE
Lock will not be deleted on "init=true"

### DIFF
--- a/.tflint.tests.hcl
+++ b/.tflint.tests.hcl
@@ -25,3 +25,11 @@ rule "terraform_unused_required_providers" {
 rule "terraform_standard_module_structure" {
   enabled = false
 }
+
+rule "terraform_documented_variables" {
+  enabled = false
+}
+
+rule "terraform_documented_outputs" {
+  enabled = false
+}

--- a/r-storage-account.tf
+++ b/r-storage-account.tf
@@ -25,7 +25,7 @@ resource "random_string" "stlaunchpadprd_suffix" {
 }
 
 resource "azurerm_management_lock" "storage_account_lock" {
-  count      = var.init || !var.storage_account_deletion_lock ? 0 : 1
+  count      = var.storage_account_deletion_lock ? 1 : 0
   name       = "storage_account_lock"
   scope      = azurerm_storage_account.this.id
   lock_level = "CanNotDelete"

--- a/tests/remote/main.tftest.hcl
+++ b/tests/remote/main.tftest.hcl
@@ -37,6 +37,9 @@ run "deploy_module" {
     runner_github_pat   = ""
     runner_github_repo  = "cloudeteer/terraform-azurerm-launchpad"
 
+    # Make the storage_account deletable
+    storage_account_deletion_lock = false
+
     # Initial deployment
     init                   = true
     init_access_ip_address = run.setup_tests.init_access_ip_address


### PR DESCRIPTION
The main problem was to have a possibility to disable the lock, because of the remote test, which needs to delete it, after its tests.
As a new variable came in "storage_account_deletion_lock", we do not need the variable "init" not any more to prevent the storage account to be deleted.

fixes #7 