### PR TITLE
Implement variable `role_definition_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,14 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_role_definition_name"></a> [role\_definition\_name](#input\_role\_definition\_name)
+
+Description: Specifies the role definition name to be assigned to the Launchpad. Allowed values: `Contributor` and `Owner`.
+
+Type: `string`
+
+Default: `"Owner"`
+
 ### <a name="input_runner_arch"></a> [runner\_arch](#input\_runner\_arch)
 
 Description: The CPU architecture to run the GitHub actions runner. Can be `x64` or `arm64`.

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -31,7 +31,7 @@ resource "azurerm_role_assignment" "management_group_owner" {
   for_each = data.azurerm_management_group.managed_by_launchpad
 
   principal_id         = azurerm_user_assigned_identity.this.principal_id
-  role_definition_name = "Owner"
+  role_definition_name = var.role_definition_name
   scope                = each.value.id
 }
 
@@ -39,7 +39,7 @@ resource "azurerm_role_assignment" "subscription_owner" {
   for_each = data.azurerm_subscription.managed_by_launchpad
 
   principal_id         = azurerm_user_assigned_identity.this.principal_id
-  role_definition_name = "Owner"
+  role_definition_name = var.role_definition_name
   scope                = each.value.id
 }
 

--- a/tests/local/input_role_definition_name.tftest.hcl
+++ b/tests/local/input_role_definition_name.tftest.hcl
@@ -1,0 +1,33 @@
+mock_provider "azurerm" {
+  source = "./tests/local/mocks"
+}
+
+run "should_succeed_with_default_role_definition_name" {
+  command = plan
+}
+
+run "should_succeed_with_role_definition_name_owner" {
+  command = plan
+
+  variables {
+    role_definition_name = "Owner"
+  }
+}
+
+run "should_succeed_with_role_definition_name_contributor" {
+  command = plan
+
+  variables {
+    role_definition_name = "Contributor"
+  }
+}
+
+run "should_fail_with_unknown_role_definition" {
+  command = plan
+
+  variables {
+    role_definition_name = "UnknownValue"
+  }
+
+  expect_failures = [var.role_definition_name]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -155,6 +155,17 @@ variable "resource_group_name" {
   type        = string
 }
 
+variable "role_definition_name" {
+  type        = string
+  description = "Specifies the role definition name to be assigned to the Launchpad. Allowed values: `Contributor` and `Owner`."
+  default     = "Owner"
+
+  validation {
+    condition     = contains(["Contributor", "Owner"], var.role_definition_name)
+    error_message = "Invalid role definition name. Allowed values are 'Contributor' and 'Owner'."
+  }
+}
+
 variable "runner_arch" {
   type        = string
   default     = "arm64"


### PR DESCRIPTION
This pull request introduces the role_definition_name variable, enhancing flexibility in role assignment. Additionally, it resolves issue #46.