### PR TITLE
Use Absolute Image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@
 [![SemVer](https://img.shields.io/badge/SemVer-2.0.0-F77F00?style=for-the-badge)](https://github.com/cloudeteer/terraform-azurerm-launchpad/releases)
 
 This module provisions all essential infrastructure components within an Azure tenant to enable secure, automated management using Terraform and GitHub. It sets up a GitHub private runner, a Terraform state storage account, and other key resources necessary for fully automated Terraform deployments. The module is designed to adhere to security best practices throughout the process.
+
 ## Design
 
 The IaC Launchpad is a collection of essential Azure resources required for managing Terraform deployments via Cloudeteer GitHub Actions. The term “Launchpad” draws an analogy to rocket science, emphasizing the foundational role it plays.
 
-[![Launchpad Design](images/diagram.svg)](images/diagram.png)
+[![Launchpad Design](https://raw.githubusercontent.com/cloudeteer/terraform-azurerm-launchpad/refs/heads/main/images/diagram.svg)](https://github.com/cloudeteer/terraform-azurerm-launchpad/blob/main/images/diagram.png)
 
 <!-- BEGIN_TF_DOCS -->
 ## Usage


### PR DESCRIPTION
This PR fixes an issue where the diagram was not displayed correctly on the Terraform and OpenTofu Registry pages. By switching to absolute image URLs, the documentation renders the diagram as expected on both platforms.