### PR TITLE
Install `kubelogin` and enhance documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The IaC Launchpad is a collection of essential Azure resources required for mana
 
 [![Launchpad Design](https://raw.githubusercontent.com/cloudeteer/terraform-azurerm-launchpad/refs/heads/main/images/diagram.svg)](https://github.com/cloudeteer/terraform-azurerm-launchpad/blob/main/images/diagram.png)
 
+## Tools
+
+For a comprehensive list of tools available on the Launchpad runner, see [TOOLS.md](TOOLS.md).
+
 <!-- BEGIN_TF_DOCS -->
 ## Usage
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,13 @@
+# Tools on Launchpad Runner
+
+The following tools are installed on the Launchpad Runner VM. The base system is a minimal Ubuntu installation, which includes standard Linux utilities. The additional tools provided are:
+
+- `az` – Azure CLI for managing Azure resources
+- `curl` – Command-line tool for transferring data with URLs
+- `jq` – Command-line JSON processor
+- `kubelogin` – Azure AD authentication helper for Kubernetes
+- `python3` – Python 3 interpreter
+- `python3-pip` – Python package installer for Python 3
+- `unzip` – Utility for extracting ZIP files
+
+> **Note:** If you require additional tools, please contact the Launchpad maintainers.

--- a/assets/install_github_actions_runner.sh.tftpl
+++ b/assets/install_github_actions_runner.sh.tftpl
@@ -30,6 +30,9 @@ ln -s /usr/bin/python3 /usr/bin/python
 # Install Azure CLI
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
+# Install Azure AKS CLI (kubelogin)
+sudo az aks install-cli
+
 RUNNER_NAME=$(hostname)
 
 # Fill variables with Terraform templatefile()

--- a/r-key-vault.tf
+++ b/r-key-vault.tf
@@ -33,6 +33,10 @@ resource "azurerm_management_lock" "key_vault_lock" {
   scope      = azurerm_key_vault.this[0].id
   lock_level = "CanNotDelete"
   notes      = "This lock prevents the deletion of the Key Vault, which contains critical infrastructure information."
+
+  depends_on = [
+    azurerm_role_assignment.key_vault_admin_current_user,
+  ]
 }
 
 resource "azurerm_key_vault" "this" {

--- a/r-storage-account.tf
+++ b/r-storage-account.tf
@@ -30,6 +30,10 @@ resource "azurerm_management_lock" "storage_account_lock" {
   scope      = azurerm_storage_account.this.id
   lock_level = "CanNotDelete"
   notes      = "This lock prevents the deletion of the Storage Account, which contains critical infrastructure information."
+
+  depends_on = [
+    azurerm_role_assignment.storage_account_blob_owner_current_user,
+  ]
 }
 
 resource "azurerm_storage_account" "this" {


### PR DESCRIPTION
Install `kubelogin` using the Azure CLI and add dependencies to prevent destruction issues. Update the documentation to include a comprehensive list of tools available on the Launchpad runner.

---

The `kubelogin` CLI will now be downloaded from https://cdn.dl.k8s.io/. Our internal documentation on the required firewall rules has been updated accordingly — [🚒 IaC Launchpad Firewall Approvals](https://cloudeteer.atlassian.net/wiki/x/JAC-Qg)