### PR TITLE
Disable automatic upgrade mode and implement upgrade policies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,19 +10,27 @@ repos:
     hooks:
       - id: terraform-docs-system
         args: ["."]
+  - repo: local
+    hooks:
+      - id: tfsort
+        name: Sort Terraform variables
+        language: system
+        types: [terraform]
+        entry: bash -c 'for f in $@; do tfsort "$f"; done' --
+        files: ^variables|outputs\.tf$
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: "v1.99.0"
     hooks:
       - id: terraform_fmt
       - id: terraform_tflint
-        exclude: ^(examples|tests)/
+        exclude: (examples|tests)/
         args:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
           - --hook-config=--delegate-chdir
       - id: terraform_tflint
         alias: terraform_tflint_examples
         name: Terraform validate examples with tflint
-        files: ^examples/
+        files: examples/
         args:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.examples.hcl
           - --hook-config=--delegate-chdir
@@ -30,13 +38,13 @@ repos:
       - id: terraform_tflint
         alias: terraform_tflint_tests
         name: Terraform validate tests with tflint
-        files: ^tests/
+        files: tests/
         args:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.tests.hcl
           - --hook-config=--delegate-chdir
 
       - id: terraform_trivy
-        exclude: ^(examples|tests)/
+        exclude: (examples|tests)/
         args:
           - --args=--skip-dirs="examples/"
           - --args=--skip-dirs="tests/"

--- a/.tflint.tests.hcl
+++ b/.tflint.tests.hcl
@@ -18,6 +18,14 @@ plugin "azurerm" {
   version = "0.28.0"
 }
 
+rule "terraform_documented_variables" {
+  enabled = false
+}
+
+rule "terraform_documented_outputs" {
+  enabled = false
+}
+
 rule "terraform_unused_required_providers" {
   enabled = false
 }

--- a/.tflint.tests.hcl
+++ b/.tflint.tests.hcl
@@ -18,14 +18,6 @@ plugin "azurerm" {
   version = "0.28.0"
 }
 
-rule "terraform_documented_variables" {
-  enabled = false
-}
-
-rule "terraform_documented_outputs" {
-  enabled = false
-}
-
 rule "terraform_unused_required_providers" {
   enabled = false
 }

--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### <a name="input_automatic_os_upgrade_policy"></a> [automatic\_os\_upgrade\_policy](#input\_automatic\_os\_upgrade\_policy)
+
+Description:     This can only be specified when `upgrade_mode` is set to either `Automatic` or `Rolling`.
+
+    Required arguments:
+
+    Argument | Description
+    -- | --
+    `disable_automatic_rollback` | Should automatic rollbacks be disabled?
+    `enable_automatic_os_upgrade` | Should OS Upgrades automatically be applied to Scale Set instances in a rolling fashion when a newer version of the OS Image becomes available?
+
+Type:
+
+```hcl
+object({
+    disable_automatic_rollback  = bool
+    enable_automatic_os_upgrade = bool
+  })
+```
+
+Default: `null`
+
 ### <a name="input_create_key_vault"></a> [create\_key\_vault](#input\_create\_key\_vault)
 
 Description: Create a central Key Vault which can be used to store secrets and keys securely during workload deployments.
@@ -275,6 +297,44 @@ Type: `string`
 
 Default: `"Owner"`
 
+### <a name="input_rolling_upgrade_policy"></a> [rolling\_upgrade\_policy](#input\_rolling\_upgrade\_policy)
+
+Description: Provides advanced configuration for the rolling upgrade policy. This block is *required* and can only be specified when `upgrade_mode` is set to `Automatic` or `Rolling`.
+
+Required arguments:
+
+Argument | Description
+-- | --
+`max_batch_instance_percent` | The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability.
+`max_unhealthy_instance_percent` | The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch.
+`max_unhealthy_upgraded_instance_percent` | The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts.
+`pause_time_between_batches` | The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in [ISO 8601 duration format](https://docs.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm) (e.g. `PT10M` to `PT90M`).
+
+Optional Arguments:
+
+Argument | Description
+-- | --
+`cross_zone_upgrades_enabled` | Should the Virtual Machine Scale Set ignore the Azure Zone boundaries when constructing upgrade batches? Possible values are true or false.
+`prioritize_unhealthy_instances_enabled` | Upgrade all unhealthy instances in a scale set before any healthy instances. Possible values are true or false.
+`maximum_surge_instances_enabled` | Create new virtual machines to upgrade the scale set, rather than updating the existing virtual machines. Existing virtual machines will be deleted once the new virtual machines are created for each batch. Possible values are true or false.
+
+Type:
+
+```hcl
+object({
+    max_batch_instance_percent              = string
+    max_unhealthy_instance_percent          = string
+    max_unhealthy_upgraded_instance_percent = string
+    pause_time_between_batches              = string
+
+    cross_zone_upgrades_enabled            = optional(bool)
+    maximum_surge_instances_enabled        = optional(bool)
+    prioritize_unhealthy_instances_enabled = optional(bool)
+  })
+```
+
+Default: `null`
+
 ### <a name="input_runner_arch"></a> [runner\_arch](#input\_runner\_arch)
 
 Description: The CPU architecture to run the GitHub actions runner. Can be `x64` or `arm64`.
@@ -394,6 +454,16 @@ Description: A mapping of tags which should be assigned to all resources in this
 Type: `map(string)`
 
 Default: `{}`
+
+### <a name="input_upgrade_mode"></a> [upgrade\_mode](#input\_upgrade\_mode)
+
+Description:     Specifies how Upgrades (e.g. changing the Image/SKU) should be performed to Virtual Machine Instances. Possible values are `Automatic`, `Manual` and `Rolling`.
+
+    **Note**: If rolling upgrades are configured and running on a Linux Virtual Machine Scale Set, they will be cancelled when Terraform tries to destroy the resource.
+
+Type: `string`
+
+Default: `"Manual"`
 
 ### <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space)
 

--- a/README.md
+++ b/README.md
@@ -513,6 +513,10 @@ Description: The ID of the subnet within the Virtual Network associated with the
 
 Description: The name of the subnet within the Virtual Network associated with the Launchpad. If `var.subnet_id` is not specified, the name of the subnet created by this module is returned. Otherwise, the name is extracted from the specified `var.subnet_id`.
 
+### <a name="output_virtual_machine_scale_set_name"></a> [virtual\_machine\_scale\_set\_name](#output\_virtual\_machine\_scale\_set\_name)
+
+Description: The name of the Azure Linux Virtual Machine Scale Set resource
+
 ### <a name="output_virtual_network_id"></a> [virtual\_network\_id](#output\_virtual\_network\_id)
 
 Description: The ID of the Azure Virtual Network (VNet) associated with the Launchpad. If `var.subnet_id` is not specified, the ID of the Virtual Network created by this module is returned. Otherwise, the Virtual Network ID is derived from the specified `var.subnet_id`.

--- a/assets/install_github_actions_runner.sh.tftpl
+++ b/assets/install_github_actions_runner.sh.tftpl
@@ -49,6 +49,10 @@ RUNNER_VERSION=${runner_version}
 # shellcheck disable=SC2154
 RUNNER_USER=${runner_user}
 
+# Install hcl2json
+curl -L -o hcl2json "https://github.com/tmccombs/hcl2json/releases/latest/download/hcl2json_linux_$RUNNER_ARCH"
+install -m 0755 hcl2json /usr/local/bin/hcl2json
+
 # Get the latest version
 if [ "$RUNNER_VERSION" = "latest" ]; then
   RUNNER_VERSION=$(curl -sS -L \

--- a/outputs.tf
+++ b/outputs.tf
@@ -46,6 +46,11 @@ output "subnet_name" {
   description = "The name of the subnet within the Virtual Network associated with the Launchpad. If `var.subnet_id` is not specified, the name of the subnet created by this module is returned. Otherwise, the name is extracted from the specified `var.subnet_id`."
 }
 
+output "virtual_machine_scale_set_name" {
+  value       = azurerm_linux_virtual_machine_scale_set.this.name
+  description = "The name of the Azure Linux Virtual Machine Scale Set resource"
+}
+
 output "virtual_network_id" {
   value = (var.subnet_id == null ? azurerm_virtual_network.this[0].id :
   join("/", slice(split("/", var.subnet_id), 0, 9)))

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -41,9 +41,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
   vtpm_enabled                    = false
   overprovision                   = false
 
-  # trigger instance update
-  custom_data = base64encode("#cloud-config\n#${sha256(local.github_runner_script)}")
-
   automatic_instance_repair {
     enabled      = true
     grace_period = "PT10M"

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -42,6 +42,8 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
   vtpm_enabled                    = false
   overprovision                   = false
 
+  custom_data = base64encode("#cloud-config\n#${sha256(local.github_runner_script)}")
+
   automatic_instance_repair {
     enabled      = true
     grace_period = "PT10M"

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -34,11 +34,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
   sku                             = "Standard_D2plds_v5"
   encryption_at_host_enabled      = false
 
-  automatic_os_upgrade_policy {
-    disable_automatic_rollback  = false
-    enable_automatic_os_upgrade = false
-  }
-
   automatic_instance_repair {
     enabled      = true
     grace_period = "PT10M"
@@ -48,17 +43,10 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
     storage_account_uri = null
   }
 
-  rolling_upgrade_policy {
-    max_batch_instance_percent              = 100
-    max_unhealthy_instance_percent          = 100
-    max_unhealthy_upgraded_instance_percent = 100
-    pause_time_between_batches              = "PT0M"
-  }
-
   extension_operations_enabled = true
   extensions_time_budget       = "PT15M"
   provision_vm_agent           = true
-  upgrade_mode                 = "Automatic"
+  upgrade_mode                 = "Manual"
   secure_boot_enabled          = false
   vtpm_enabled                 = false
   overprovision                = false

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -43,6 +43,11 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
     storage_account_uri = null
   }
 
+  scale_in {
+    force_deletion_enabled = false
+    rule                   = "OldestVM"
+  }
+
   extension_operations_enabled = true
   extensions_time_budget       = "PT15M"
   provision_vm_agent           = true

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -32,15 +32,15 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
   resource_group_name = var.resource_group_name
   tags                = var.tags
 
-  computer_name_prefix = "vm-${var.name}"
-  admin_password       = random_password.virtual_machine_scale_set_admin_password.result
-  admin_username       = local.admin_username
-  upgrade_mode         = var.upgrade_mode
-  instances            = var.runner_vm_instances
+  computer_name_prefix       = "vm-${var.name}"
+  admin_password             = random_password.virtual_machine_scale_set_admin_password.result
+  admin_username             = local.admin_username
+  upgrade_mode               = var.upgrade_mode
+  instances                  = var.runner_vm_instances
+  encryption_at_host_enabled = var.encryption_at_host_enabled
 
   disable_password_authentication = false
   sku                             = "Standard_D2plds_v5"
-  encryption_at_host_enabled      = false
   extension_operations_enabled    = true
   extensions_time_budget          = "PT15M"
   provision_vm_agent              = true


### PR DESCRIPTION
## Description

Changes include disabling the automatic upgrade mode and setting a scale-in policy to the oldest VM. Additionally, new variables for upgrade modes and policies have been introduced, along with sorting of VMSS parameters and removal of unnecessary custom data for instance upgrades.

This change prepares the Launchpad for a **two-stage upgrade process**. Together with upcoming changes in our **IaCv3 deployment workflows**, this enables safer and more controlled VMSS upgrades.

1. The VMSS will be configured with `upgrade_mode = "Manual"` by default (handled by this PR). This prevents automatic replacement of VMSS instances during configuration changes.

2. VMSS instances will be upgraded manually via `az` CLI. This will be handled by our IaCv3 deployment workflows.
   
   Example CLI for upgrading outdated VMSS instances:
   ```shell
    rg=rg-launchpad-01
    vmss=vmss-launchpad-prd-gwc

    outdated_instance_ids=$(az vmss list-instances \
      --name "$vmss" \
      --resource-group "$rg" \
      --query "[?latestModelApplied==\`false\`].instanceId" \
      --output tsv)

    for id in $outdated_instance_ids; do
      az vmss update-instances \
        --name "$vmss" \
        --resource-group "$rg" \
        --instance-ids "$id"
    done
   ```

## PR Checklist
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added documentation written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have checked for a proper tag for this PR: `breaking-change`, `feature`, `fix`, `other`, `ignore-release`
- [x] I have used a **meaningful** PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #19. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking changes. Existing deployments must explicitly set `var.upgrade_mode`, `var.rolling_upgrade_policy`, and `var.automatic_os_upgrade_policy` to avoid Terraform drift causing a recreation of the VMSS resource.