### PR TITLE
OE-627: Changing RoleAssignment to ResourceGroup

### DIFF
--- a/.tflint.tests.hcl
+++ b/.tflint.tests.hcl
@@ -25,3 +25,11 @@ rule "terraform_unused_required_providers" {
 rule "terraform_standard_module_structure" {
   enabled = false
 }
+
+rule "terraform_documented_variables" {
+  enabled = false
+}
+
+rule "terraform_documented_outputs" {
+  enabled = false
+}

--- a/r-key-vault.tf
+++ b/r-key-vault.tf
@@ -95,5 +95,5 @@ resource "azurerm_role_assignment" "key_vault_admin_current_user" {
   description          = "Temporary role assignment. Delete this assignment if unsure why it is still existing."
   principal_id         = local.init_access_azure_principal_id
   role_definition_name = "Key Vault Administrator"
-  scope                = azurerm_key_vault.this[0].id
+  scope                = split("/providers/", azurerm_key_vault.this[0].id)[0] # resource group id
 }

--- a/r-storage-account.tf
+++ b/r-storage-account.tf
@@ -103,5 +103,5 @@ resource "azurerm_role_assignment" "storage_account_blob_owner_current_user" {
   description          = "Temporary role assignment. Delete this assignment if unsure why it is still existing."
   principal_id         = local.init_access_azure_principal_id
   role_definition_name = "Storage Blob Data Owner"
-  scope                = split("/providers/", azurerm_storage_account.this.id)[0] // Resource-group ID
+  scope                = split("/providers/", azurerm_storage_account.this.id)[0] # resource group id
 }

--- a/r-storage-account.tf
+++ b/r-storage-account.tf
@@ -14,8 +14,6 @@ locals {
       "pe", azurerm_storage_account.this.name, "prd", local.location_short[var.location], var.name_suffix
     ]))
   )
-
-  resource_group_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}"
 }
 
 resource "random_string" "stlaunchpadprd_suffix" {
@@ -105,5 +103,5 @@ resource "azurerm_role_assignment" "storage_account_blob_owner_current_user" {
   description          = "Temporary role assignment. Delete this assignment if unsure why it is still existing."
   principal_id         = local.init_access_azure_principal_id
   role_definition_name = "Storage Blob Data Owner"
-  scope                = local.resource_group_id
+  scope                = split("/providers/", azurerm_storage_account.this.id)[0] // Resource-group ID
 }

--- a/r-storage-account.tf
+++ b/r-storage-account.tf
@@ -14,6 +14,8 @@ locals {
       "pe", azurerm_storage_account.this.name, "prd", local.location_short[var.location], var.name_suffix
     ]))
   )
+
+  resource_group_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}"
 }
 
 resource "random_string" "stlaunchpadprd_suffix" {
@@ -103,5 +105,5 @@ resource "azurerm_role_assignment" "storage_account_blob_owner_current_user" {
   description          = "Temporary role assignment. Delete this assignment if unsure why it is still existing."
   principal_id         = local.init_access_azure_principal_id
   role_definition_name = "Storage Blob Data Owner"
-  scope                = azurerm_storage_account.this.id
+  scope                = local.resource_group_id
 }

--- a/tests/remote/resources.tf
+++ b/tests/remote/resources.tf
@@ -1,9 +1,9 @@
 variable "location" {
-  type        = string
+  type = string
 }
 
 variable "resource_group_name" {
-  type        = string
+  type = string
 }
 
 resource "random_string" "resource_group_suffix" {
@@ -18,11 +18,11 @@ resource "azurerm_resource_group" "tftest" {
 }
 
 output "resource_group_name" {
-  value       = azurerm_resource_group.tftest.name
+  value = azurerm_resource_group.tftest.name
 }
 
 output "resource_group_location" {
-  value       = azurerm_resource_group.tftest.location
+  value = azurerm_resource_group.tftest.location
 }
 
 data "http" "init_access_ip_address" {
@@ -30,5 +30,5 @@ data "http" "init_access_ip_address" {
 }
 
 output "init_access_ip_address" {
-  value       = trimspace(data.http.init_access_ip_address.response_body)
+  value = trimspace(data.http.init_access_ip_address.response_body)
 }

--- a/tests/remote/resources.tf
+++ b/tests/remote/resources.tf
@@ -1,9 +1,11 @@
 variable "location" {
-  type = string
+  type        = string
+  description = "The geographic location where the resources will be deployed. This is must be a region name supported by Azure."
 }
 
 variable "resource_group_name" {
-  type = string
+  type        = string
+  description = "The name of the resource group in which the virtual machine should exist. Changing this forces a new resource to be created."
 }
 
 resource "random_string" "resource_group_suffix" {
@@ -18,11 +20,13 @@ resource "azurerm_resource_group" "tftest" {
 }
 
 output "resource_group_name" {
-  value = azurerm_resource_group.tftest.name
+  value       = azurerm_resource_group.tftest.name
+  description = "The name of the resource group in which the virtual machine should exist. Changing this forces a new resource to be created."
 }
 
 output "resource_group_location" {
-  value = azurerm_resource_group.tftest.location
+  value       = azurerm_resource_group.tftest.location
+  description = "The geographic location where the resources will be deployed. This is must be a region name supported by Azure."
 }
 
 data "http" "init_access_ip_address" {
@@ -30,5 +34,6 @@ data "http" "init_access_ip_address" {
 }
 
 output "init_access_ip_address" {
-  value = trimspace(data.http.init_access_ip_address.response_body)
+  value       = trimspace(data.http.init_access_ip_address.response_body)
+  description = "The IP Address of your current public IP in order to access the new created resources. For more information please go here https://github.com/cloudeteer/terraform-azurerm-launchpad/blob/main/INSTALL.md "
 }

--- a/tests/remote/resources.tf
+++ b/tests/remote/resources.tf
@@ -1,11 +1,9 @@
 variable "location" {
   type        = string
-  description = "The geographic location where the resources will be deployed. This is must be a region name supported by Azure."
 }
 
 variable "resource_group_name" {
   type        = string
-  description = "The name of the resource group in which the virtual machine should exist. Changing this forces a new resource to be created."
 }
 
 resource "random_string" "resource_group_suffix" {
@@ -21,12 +19,10 @@ resource "azurerm_resource_group" "tftest" {
 
 output "resource_group_name" {
   value       = azurerm_resource_group.tftest.name
-  description = "The name of the resource group in which the virtual machine should exist. Changing this forces a new resource to be created."
 }
 
 output "resource_group_location" {
   value       = azurerm_resource_group.tftest.location
-  description = "The geographic location where the resources will be deployed. This is must be a region name supported by Azure."
 }
 
 data "http" "init_access_ip_address" {
@@ -35,5 +31,4 @@ data "http" "init_access_ip_address" {
 
 output "init_access_ip_address" {
   value       = trimspace(data.http.init_access_ip_address.response_body)
-  description = "The IP Address of your current public IP in order to access the new created resources. For more information please go here https://github.com/cloudeteer/terraform-azurerm-launchpad/blob/main/INSTALL.md "
 }


### PR DESCRIPTION
**Problem:**
It is not possible to delete the AzureRoleAssignemt once the lock for Storage Account is created.

**Workaround:**
In order to remove the temporary AzureRoleAssignemt, you had to remove the lock of the Storage Account manually and then restart the Pipeline.

**Fix:**
As the lock does only apply on the scope of the Storage Account itself including the AzureRoleAsignemnts. the scope of the AzureRoleAssignment will be changed to the ResourceGroup.