### PR TITLE
Add `encryption_at_host_enabled` variable for VM scale set

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,11 @@ Default: `true`
 
 ### <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled)
 
-Description: Toggle host-based encryption for the Virtual Machine Scale Set. Set to `true` to encrypt data end-to-end between the VM and the storage service. Refer to the [Azure host-based encryption guidance](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell) for requirements and limitations.
+Description: Toggle host-based encryption for the Virtual Machine Scale Set. Set to `true` to encrypt data end-to-end between the VM and the storage service.
+
+**NOTE**: Requires the provider feature `Microsoft.Compute/EncryptionAtHost` to be enabled at the subscription level.
+
+Refer to the [Azure host-based encryption guidance](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell) for further requirements and limitations.
 
 Type: `bool`
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled)
+
+Description: Toggle host-based encryption for the Virtual Machine Scale Set. Set to `true` to encrypt data end-to-end between the VM and the storage service. Refer to the [Azure host-based encryption guidance](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell) for requirements and limitations.
+
+Type: `bool`
+
+Default: `true`
+
 ### <a name="input_init"></a> [init](#input\_init)
 
 Description: Is used for initiating the module itself for the first time. For more information please go here https://github.com/cloudeteer/terraform-azurerm-launchpad/blob/main/INSTALL.md

--- a/r-virtual-machine-scale-set.tf
+++ b/r-virtual-machine-scale-set.tf
@@ -30,9 +30,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
   admin_username                  = local.admin_username
   computer_name_prefix            = "vm-${var.name}"
   disable_password_authentication = false
+  encryption_at_host_enabled      = var.encryption_at_host_enabled
   instances                       = var.runner_vm_instances
   sku                             = "Standard_D2plds_v5"
-  encryption_at_host_enabled      = false
 
   automatic_os_upgrade_policy {
     disable_automatic_rollback  = false

--- a/variables.tf
+++ b/variables.tf
@@ -218,7 +218,11 @@ variable "encryption_at_host_enabled" {
   type        = bool
   default     = true
   description = <<-EOT
-    Toggle host-based encryption for the Virtual Machine Scale Set. Set to `true` to encrypt data end-to-end between the VM and the storage service. Refer to the [Azure host-based encryption guidance](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell) for requirements and limitations.
+    Toggle host-based encryption for the Virtual Machine Scale Set. Set to `true` to encrypt data end-to-end between the VM and the storage service.
+
+    **NOTE**: Requires the provider feature `Microsoft.Compute/EncryptionAtHost` to be enabled at the subscription level.
+
+    Refer to the [Azure host-based encryption guidance](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell) for further requirements and limitations.
   EOT
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -214,6 +214,14 @@ variable "runner_public_ip_address" {
   description = "Set the value of this variable to `true` if you want to allocate a public IP address to each instance within the Virtual Machine Scale Set. Enabling this option may be necessary to establish internet access when a direct connection to a HUB is currently unavailable."
 }
 
+variable "encryption_at_host_enabled" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    Toggle host-based encryption for the Virtual Machine Scale Set. Set to `true` to encrypt data end-to-end between the VM and the storage service. Refer to the [Azure host-based encryption guidance](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell) for requirements and limitations.
+  EOT
+}
+
 variable "runner_user" {
   type        = string
   default     = "actions-runner"


### PR DESCRIPTION
## Description

Introduce a new variable to toggle host-based encryption for the Virtual Machine Scale Set, enhancing data security between the VM and the storage service. Update the VM scale set configuration to utilize this variable.

## PR Checklist
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added documentation written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have checked for a proper tag for this PR: `breaking-change`, `feature`, `fix`, `other`, `ignore-release`
- [x] I have used a **meaningful** PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves #57

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

This change will redeploy the ephemeral Launchpad VMSS resource. Not really breaking, but need to be considered.